### PR TITLE
Added ability to change device volume level programatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Add the view to your hierarchy:
 view.addSubview(volume)
 ```
 
+To change the volume programatically:
+```swift
+_ = try? volume.setVolumeLevel(0.5)
+```
+
 #WIP
 This is currently in development, feedback is really welcome. 
 


### PR DESCRIPTION
I have exposed the getter for `volumeLevel` publicly and added a function to change the volume of the device programatically. It includes the option to animate the change or not.

I have also added the new functionality to the README.