### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ Updated library to Swift 3.0
 
 ## [0.1.1](https://github.com/andreamazz/SubtleVolume/releases/tag/0.1.1)
 
-###Fixed
+### Fixed
 - Removed observer on dealloc (See #6).
 
 ## [0.1.0](https://github.com/andreamazz/SubtleVolume/releases/tag/0.1.0)
 
-###Added
+### Added
 - Carthage Support


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
