### PR TITLE
Accessory image fix

### DIFF
--- a/Source/SubtleVolume.swift
+++ b/Source/SubtleVolume.swift
@@ -276,9 +276,9 @@ public enum SubtleVolumeError: Error {
     let image = delegate?.subtleVolume?(self, accessoryFor: volumeLevel)
     accessory.image = image
     var insets = UIEdgeInsets.zero
-    if image != nil {
-      insets.left += (frame.height)
-      accessory.frame = CGRect(x: 0, y: 0, width: frame.height, height: frame.height)
+    if let image = image {
+      insets.left += (image.size.width)
+      accessory.frame = CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
     }
     insets.left += padding.width
     insets.right += padding.width


### PR DESCRIPTION
When trying to apply an accessory image to the volume bar, I noticed that it wasn't displaying properly. The code was basing the accessory frame on the bar height and since my bar height was quite smaller than the accessory image, that was causing the issue. I updated it so that the image size is used instead.